### PR TITLE
include external quickstart

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -30,6 +30,11 @@ paginate = 10
     weight = 15
 
 [[menu.main]]
+    name = "Quickstart"
+    url = "/quickstart"
+    weight = 16
+
+[[menu.main]]
     name = "Blog"
     url  = "/blog/"
     weight = 20
@@ -135,4 +140,9 @@ paginate = 10
     enable = true
     title = "About Eclipse KUKSA"
 
+[[module.imports]]
+path = "github.com/eclipse/kuksa.val"
 
+  [[module.imports.mounts]]
+  source = "doc/quickstart.md"
+  target = "content/quickstart.md"

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/eclipse/kuksa.website
+
+go 1.20


### PR DESCRIPTION
This adds a quickstart tab and references the quickstart from the Kuksa.val repository for the content.
To enable the download from other repositories during the Hugo build, there Hugo project is turned into a module.

Closes #54 